### PR TITLE
Add ReadFrom for zero copy from os.File

### DIFF
--- a/alg_linux.go
+++ b/alg_linux.go
@@ -109,9 +109,9 @@ func (h *ihash) Close() error {
 
 func (h *ihash) ReadFrom(r io.Reader) (int64, error) {
 	if f, ok := r.(*os.File); ok {
-		//if w, err, handled := h.sendfile(f, -1); handled {
-		//	return w, err
-		//}
+		if w, err, handled := h.sendfile(f, -1); handled {
+			return w, err
+		}
 		if w, err, handled := h.splice(f, -1); handled {
 			return w, err
 		}
@@ -124,9 +124,9 @@ func (h *ihash) ReadFrom(r io.Reader) (int64, error) {
 
 func (h *ihash) readFromLimitedReader(lr *io.LimitedReader) (int64, error) {
 	if f, ok := lr.R.(*os.File); ok {
-		//if w, err, handled := h.sendfile(f, lr.N); handled {
-		//	return w, err
-		//}
+		if w, err, handled := h.sendfile(f, lr.N); handled {
+			return w, err
+		}
 		if w, err, handled := h.splice(f, lr.N); handled {
 			return w, err
 		}

--- a/alg_linux.go
+++ b/alg_linux.go
@@ -148,14 +148,13 @@ func (h *ihash) splice(f *os.File, remain int64) (written int64, err error, hand
 	}
 	// mmap must align on a page boundary
 	// mmap from 0, use data from offset
-	bytes, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()),
+	mmap, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()),
 		syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
 		return 0, nil, false
 	}
-	bytes = bytes[offset : offset+remain]
-	defer syscall.Munmap(bytes)
-
+	defer syscall.Munmap(mmap)
+	bytes := mmap[offset : offset+remain]
 	var (
 		total = len(bytes)
 		start = 0

--- a/alg_linux.go
+++ b/alg_linux.go
@@ -205,6 +205,7 @@ func (h *ihash) sendfile(f *os.File, remain int64) (written int64, err error, ha
 	err = sc.Read(func(fd uintptr) bool {
 		for {
 			n, werr = syscall.Sendfile(h.s.FD(), int(fd), &offset, int(remain))
+			written += int64(n)
 			if werr != nil {
 				break
 			}
@@ -212,7 +213,6 @@ func (h *ihash) sendfile(f *os.File, remain int64) (written int64, err error, ha
 				break
 			}
 			remain -= int64(n)
-			written += int64(n)
 		}
 		return true
 	})
@@ -301,6 +301,7 @@ type sysPipe struct {
 func (p *sysPipe) Splice(out, size, flags int) (int64, error) {
 	return unix.Splice(p.fd, nil, out, nil, size, flags)
 }
+
 func (p *sysPipe) Vmsplice(b []byte, flags int) (int, error) {
 	iov := unix.Iovec{
 		Base: &b[0],


### PR DESCRIPTION
1. Add Readfrom to process os.File with zero copy.
2. Fix Wirte partial issue, return `n` instead `len(b)`.
3. Update test.

Signed-off-by: Jim Ma <majinjing3@gmail.com>